### PR TITLE
Hash error-checking (ref #4)

### DIFF
--- a/src/core/hash-table.lisp
+++ b/src/core/hash-table.lisp
@@ -57,7 +57,8 @@
 (in-package :cl21.core.hash-table)
 
 (defun group (source n)
-  (if (zerop n) (error "zero length"))
+  (if (zerop n)
+      (error "zero length"))
   (labels ((rec (source acc)
              (let ((rest (nthcdr n source)))
                (if (consp rest)


### PR DESCRIPTION
Added error checking for hash-table:
1. Check if hash-table literal has an even number of elements
2. Check if hash-table literal has repeated keys
Talked about it int #4.
