### PR TITLE
Prevent null arg to defconstant's docstring.

### DIFF
--- a/src/core.lisp
+++ b/src/core.lisp
@@ -237,13 +237,13 @@
    :once-only))
 (in-package :cl21.core)
 
-(cl:defconstant +multiple-values-limit+
+(define-constant +multiple-values-limit+
   multiple-values-limit
-  #.(documentation 'multiple-values-limit 'variable))
+  :documentation #.(documentation 'multiple-values-limit 'variable))
 
-(cl:defconstant +internal-time-units-per-second+
+(define-constant +internal-time-units-per-second+
   internal-time-units-per-second
-  #.(documentation 'internal-time-units-per-second 'variable))
+  :documentation #.(documentation 'internal-time-units-per-second 'variable))
 
 ;; concatenating all sub-packages into cl21
 (cl:dolist (package-name '(:cl21.core.types

--- a/src/core/array.lisp
+++ b/src/core/array.lisp
@@ -2,7 +2,8 @@
 (defpackage cl21.core.array
   (:use :cl)
   (:import-from :alexandria
-                :copy-array)
+                :copy-array
+                :define-constant)
   (:export :array
            :simple-array
            :vector
@@ -57,17 +58,17 @@
            :copy-array))
 (in-package :cl21.core.array)
 
-(defconstant +array-dimension-limit+
+(define-constant +array-dimension-limit+
   array-dimension-limit
-  #.(documentation 'array-dimension-limit 'variable))
+  :documentation #.(documentation 'array-dimension-limit 'variable))
 
-(defconstant +array-rank-limit+
+(define-constant +array-rank-limit+
   array-rank-limit
-  #.(documentation 'array-rank-limit 'variable))
+  :documentation #.(documentation 'array-rank-limit 'variable))
 
-(defconstant +array-total-size-limit+
+(define-constant +array-total-size-limit+
   array-total-size-limit
-  #.(documentation 'array-total-size-limit 'variable))
+  :documentation #.(documentation 'array-total-size-limit 'variable))
 
 (defmacro adjustable-vector (&key (dimension nil dimension-specified-p) initial-contents)
   "A variant of `cl:vector' that returns an adjustable vector, not a simple-vector."

--- a/src/core/character.lisp
+++ b/src/core/character.lisp
@@ -1,6 +1,8 @@
 (in-package :cl-user)
 (defpackage cl21.core.character
   (:use :cl)
+  (:import-from :alexandria
+               :define-constant)
   (:export :character
            :base-char
            :standard-char
@@ -39,6 +41,6 @@
            :+char-code-limit+))
 (in-package :cl21.core.character)
 
-(defconstant +char-code-limit+
+(define-constant +char-code-limit+
   char-code-limit
-  #.(documentation 'char-code-limit 'variable))
+  :documentation #.(documentation 'char-code-limit 'variable))

--- a/src/core/function.lisp
+++ b/src/core/function.lisp
@@ -7,7 +7,8 @@
                 :conjoin
                 :disjoin
                 :curry
-                :rcurry)
+                :rcurry
+                :define-constant)
   (:export
    :lambda
    :apply
@@ -35,17 +36,17 @@
    :+lambda-parameters-limit+))
 (in-package :cl21.core.function)
 
-(defconstant +call-arguments-limit+
+(define-constant +call-arguments-limit+
   call-arguments-limit
-  #.(documentation 'call-arguments-limit 'variable))
+  :documentation #.(documentation 'call-arguments-limit 'variable))
 
-(defconstant +lambda-list-keywords+
+(define-constant +lambda-list-keywords+
   lambda-list-keywords
-  #.(documentation 'lambda-list-keywords 'variable))
+  :documentation #.(documentation 'lambda-list-keywords 'variable))
 
-(defconstant +lambda-parameters-limit+
+(define-constant +lambda-parameters-limit+
   lambda-parameters-limit
-  #.(documentation 'lambda-parameters-limit 'variable))
+  :documentation #.(documentation 'lambda-parameters-limit 'variable))
 
 
 (deftype function () 'cl:function)

--- a/src/core/number.lisp
+++ b/src/core/number.lisp
@@ -1,6 +1,8 @@
 (in-package :cl-user)
 (defpackage cl21.core.number
   (:use :cl)
+  (:import-from :alexandria
+                :define-constant)
   (:export :number
            :complex
            :real
@@ -194,20 +196,22 @@
            :+long-float-negative-epsilon+))
 (in-package :cl21.core.number)
 
-(defconstant +pi+ pi
-  #.(documentation 'pi 'variable))
+(define-constant +pi+ pi
+  :documentation #.(documentation 'pi 'variable))
 
-(defconstant +ii+ #C(0 1) "The imaginary number `i = sqrt(-1)`.")
+(define-constant +ii+ #C(0 1)
+  :documentation "The imaginary number `i = sqrt(-1)`.")
 
-(defconstant +ee+ (exp 1.0d0) "The exponential number `e = 2.71828...`.")
+(define-constant +ee+ (exp 1.0d0)
+  :documentation "The exponential number `e = 2.71828...`.")
 
-(defconstant +most-negative-fixnum+
+(define-constant +most-negative-fixnum+
   most-negative-fixnum
-  #.(documentation 'most-negative-fixnum 'variable))
+  :documentation #.(documentation 'most-negative-fixnum 'variable))
 
-(defconstant +most-positive-fixnum+
+(define-constant +most-positive-fixnum+
   most-positive-fixnum
-  #.(documentation 'most-positive-fixnum 'variable))
+  :documentation #.(documentation 'most-positive-fixnum 'variable))
 
 #.`(progn
      ,@(loop for var in '(boole-1
@@ -260,5 +264,5 @@
                           double-float-negative-epsilon
                           long-float-epsilon
                           long-float-negative-epsilon)
-             collect `(defconstant ,(intern (format nil "+~A+" var))
-                        ,var ,(documentation var 'variable))))
+             collect `(define-constant ,(intern (format nil "+~A+" var))
+                        ,var :documentation ,(documentation var 'variable))))


### PR DESCRIPTION
It's specified to be a string and CCL signals an error on nil.
