### PR TITLE
Add +lambda-list-keywords+ define-constant :test

### DIFF
--- a/src/core/function.lisp
+++ b/src/core/function.lisp
@@ -43,7 +43,8 @@
 
 (define-constant +lambda-list-keywords+
   lambda-list-keywords
-  :documentation #.(documentation 'lambda-list-keywords 'variable))
+  :documentation #.(documentation 'lambda-list-keywords 'variable)
+  :test #'equal)
 
 (define-constant +lambda-parameters-limit+
   lambda-parameters-limit


### PR DESCRIPTION
Because it is not always #'eql. 
