### PR TITLE
Separate some functionalities to cl21.ext.

### DIFF
--- a/cl21.asd
+++ b/cl21.asd
@@ -25,7 +25,7 @@
                :iterate)
   :components ((:module "src"
                 :components
-                ((:file "cl21" :depends-on ("core"))
+                ((:file "cl21" :depends-on ("core" "ext"))
                  (:file "core" :depends-on ("core-subpackages"))
                  (:file "asdf" :depends-on ("cl21" "core-subpackages"))
                  (:module "core-subpackages"
@@ -48,10 +48,15 @@
                    (:file "file")
                    (:file "stream")
                    (:file "generic" :depends-on ("types"))
-                   (:file "repl")
                    (:file "readtable" :depends-on ("function" "array" "sequence" "cons"))
                    (:file "environment")
                    (:file "util" :depends-on ("environment"))))
+                 (:module "ext"
+                  :components
+                  ((:file "debugger")
+                   (:file "repl")
+                   (:file "compiler-macro")
+                   (:file "trace")))
                  (:module "stdlib"
                   :depends-on ("core")
                   :components

--- a/src/cl21.lisp
+++ b/src/cl21.lisp
@@ -2,7 +2,11 @@
 (cl:in-package :cl21)
 
 (cl:eval-when (:compile-toplevel :load-toplevel :execute)
-  (cl:dolist (#1=#:package-name '(:cl21.core))
+  (cl:dolist (#1=#:package-name '(:cl21.core
+                                  :cl21.ext.debugger
+                                  :cl21.ext.repl
+                                  :cl21.ext.compiler-macro
+                                  :cl21.ext.trace))
     (cl:let ((#2=#:package (cl:find-package #1#)))
       (cl:unless #2#
         (cl:error "Package \"~A\" doesn't exist." #1#))

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -26,8 +26,6 @@
    :t
    :nil
 
-   :compiler-macro-function
-   :define-compiler-macro
    :defmacro
    :macro-function
    :macroexpand
@@ -203,9 +201,6 @@
    :get-universal-time
    :get-decoded-time
    :sleep
-   :trace
-   :untrace
-   :step
    :time
    :+internal-time-units-per-second+
    :get-internal-real-time
@@ -213,7 +208,6 @@
    :disassemble
    :documentation
    :variable
-   :compiler-macro
    :room
    :ed
    :dribble
@@ -267,7 +261,6 @@
                            :cl21.core.file
                            :cl21.core.stream
                            :cl21.core.generic
-                           :cl21.core.repl
                            :cl21.core.readtable
                            :cl21.core.environment))
   (cl:let ((package (cl:find-package package-name)))

--- a/src/core/condition.lisp
+++ b/src/core/condition.lisp
@@ -23,9 +23,7 @@
            :simple-error
            :simple-warning
            :invoke-debugger
-           :break
-           :*debugger-hook*
-           :*break-on-signals*
+           :*break-on-signals*    ;; TODO: move to somewhere
            :handler-bind
            :handler-case
            :ignore-errors

--- a/src/core/object.lisp
+++ b/src/core/object.lisp
@@ -257,6 +257,4 @@
    :update-instance-for-different-class
    :update-instance-for-redefined-class
 
-   :print-object
-   :describe-object
-   ))
+   :print-object))

--- a/src/core/stream.lisp
+++ b/src/core/stream.lisp
@@ -109,7 +109,6 @@
            :*query-io*
            :*standard-input*
            :*standard-output*
-           :*trace-output*
            :*terminal-io*
            :stream-error
            :stream-error-stream

--- a/src/ext/compiler-macro.lisp
+++ b/src/ext/compiler-macro.lisp
@@ -1,0 +1,6 @@
+(in-package :cl-user)
+(defpackage cl21.ext.compiler-macro
+  (:use :cl)
+  (:export :compiler-macro-function
+           :define-compiler-macro
+           :compiler-macro))

--- a/src/ext/debugger.lisp
+++ b/src/ext/debugger.lisp
@@ -1,0 +1,7 @@
+(in-package :cl-user)
+(defpackage cl21.ext.debugger
+  (:use :cl)
+  (:export :invoke-debugger
+           :break
+           :step ;; NOTE: I'm not sure this function is still useful.
+           :*debugger-hook*))

--- a/src/ext/repl.lisp
+++ b/src/ext/repl.lisp
@@ -1,5 +1,5 @@
 (in-package :cl-user)
-(defpackage cl21.core.repl
+(defpackage cl21.ext.repl
   (:use :cl)
   (:import-from :repl-utilities
                 :doc
@@ -18,6 +18,7 @@
 
            :inspect
            :describe
+           :describe-object
            :apropos
            :apropos-list
 

--- a/src/ext/trace.lisp
+++ b/src/ext/trace.lisp
@@ -1,0 +1,6 @@
+(in-package :cl-user)
+(defpackage cl21.ext.trace
+  (:use :cl)
+  (:export :trace
+           :untrace
+           :*trace-output*))


### PR DESCRIPTION
This separates some functionalities to cl21.ext namespace.
- cl21.ext.debugger
- cl21.ext.compiler-macro
- cl21.ext.repl
- cl21.ext.trace
