### PR TITLE
Rename 'lm' to 'la'.

### DIFF
--- a/src/core/function.lisp
+++ b/src/core/function.lisp
@@ -11,7 +11,7 @@
                 :define-constant)
   (:export
    :lambda
-   :lm
+   :la
    :apply
    :defun
    :fdefinition
@@ -71,7 +71,7 @@
                      (mapcar (lambda (x) `(function ,x)) rest)
                      rest))))))
 
-(defmacro lm (args &body body)
+(defmacro la (args &body body)
   "A shorthand for LAMBDA.
 
 Currently this cannot be used at a function position."


### PR DESCRIPTION
I thought I would get used to `lm`, the new `lambda` name, but I still don't.

I think `la` would be better than `lm` because its pronunciation is quite clear, as @snmsts mentioned at https://github.com/cl21/cl21/issues/35#issuecomment-36416609.

la la la.
