### PR TITLE
Add .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: common-lisp
 
 env:
   matrix:
-#    - LISP=abcl
+    - LISP=abcl
     - LISP=allegro
     - LISP=sbcl
     - LISP=sbcl32

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
     - LISP=ccl32
     - LISP=clisp
     - LISP=clisp32
-#    - LISP=cmucl
     - LISP=ecl
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,8 @@ install:
       curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;
     fi
 
-  - git clone https://github.com/fukamachi/prove
-
 script:
-  - cl -e '(in-package :cl-user)'
+  - cl -e "(in-package :cl-user)"
        -e "(ql:quickload '(prove cl21))"
        -e '(setf prove:*debug-on-error* t)'
        -e '(setf *debugger-hook*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: common-lisp
 
 env:
   matrix:
-    - LISP=abcl
+#    - LISP=abcl
     - LISP=allegro
     - LISP=sbcl
     - LISP=sbcl32
@@ -12,11 +12,6 @@ env:
     - LISP=clisp32
 #    - LISP=cmucl
     - LISP=ecl
-
-#matrix:
-#  allow_failures:
-    # CIM not available for CMUCL
-#    - env: LISP=cmucl
 
 install:
   - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^# cl-travis' > /dev/null;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: common-lisp
+
+env:
+  matrix:
+#    - LISP=abcl
+    - LISP=allegro
+    - LISP=sbcl
+    - LISP=sbcl32
+    - LISP=ccl
+    - LISP=ccl32
+    - LISP=clisp
+    - LISP=clisp32
+#    - LISP=cmucl
+    - LISP=ecl
+
+#matrix:
+#  allow_failures:
+    # CIM not available for CMUCL
+#    - env: LISP=cmucl
+
+install:
+  - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^# cl-travis' > /dev/null;
+    then
+      ./install.sh;
+    else
+      curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;
+    fi
+
+  - git clone https://github.com/fukamachi/prove
+
+script:
+  - cl -e '(in-package :cl-user)'
+       -e "(ql:quickload '(prove cl21))"
+       -e '(setf prove:*debug-on-error* t)'
+       -e '(setf *debugger-hook*
+                 (lambda (c h)
+                   (declare (ignore c h))
+                   (uiop:quit -1)))'
+       -e '(let ((test-results (prove:run :cl21-test)))
+             (or test-results
+                 (uiop:quit -1)))'


### PR DESCRIPTION
Adding `.travis.yml` file to test with [Travis CI](https://travis-ci.org/).

I believe adding such pervasive test support across different implementations is important to keep cl21 as close as possible to Common Lisp.
