### PR TITLE
re-split: add standard-char to etypecase with convenience wrapper

### DIFF
--- a/src/stdlib/re.lisp
+++ b/src/stdlib/re.lisp
@@ -39,7 +39,9 @@
   (declare (ignore start end limit))
   (apply #'ppcre:split (etypecase re
                          (function (funcall re))
-                         (string re)) target-string keys))
+                         (string re)
+                         (standard-char (string re)))
+         target-string keys))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   #-ccl


### PR DESCRIPTION
So I can do this:

````
CL-USER> (re-split #\newline "some string that
spans some lines")
("some string that" "spans some lines")
CL-USER> 
````