### PR TITLE
take: accept a bigger end limit than sequence's length

### DIFF
--- a/src/core/sequence.lisp
+++ b/src/core/sequence.lisp
@@ -934,15 +934,21 @@ implemented for the class of SEQUENCE."))
 
 (defun take (n sequence)
   (etypecase sequence
-    (cl:sequence (cl:subseq sequence 0 n))
+    (cl:sequence (cl:subseq sequence 0 (if (> n (length sequence))
+                                           (length sequence)
+                                           n)))
     (abstract-sequence (abstract-take n sequence))))
 (define-typecase-compiler-macro take (n sequence)
   (typecase sequence
-    (cl:sequence `(cl:subseq ,sequence 0 ,n))))
+    (cl:sequence `(cl:subseq ,sequence 0 (if (> ,n (length ,sequence))
+                                             (length ,sequence)
+                                             ,n)))))
 
 (defgeneric abstract-take (n sequence)
   (:method (n (sequence abstract-sequence))
-    (abstract-subseq sequence 0 n)))
+    (abstract-subseq sequence 0 (if (> n (abstract-length sequence))
+                                    (abstract-length sequence)
+                                    n))))
 
 (defun drop (n sequence)
   (etypecase sequence

--- a/t/sequence.lisp
+++ b/t/sequence.lisp
@@ -45,6 +45,10 @@
     #(1 3 5)
     :test #'equalp
     "take")
+(is (take 100 #(1 3 5 6 7 8))
+    #(1 3 5 6 7 8)
+    :test #'equalp
+    "take")
 (is (take 3 "Hello, World!")
     "Hel"
     "take")


### PR DESCRIPTION
That's my try at the fix. Please explain if there's a better way !

This adds compilation warnings, for example:

    (is (take 3 '(1 3 5 6 7 8))
        '(1 3 5)
        "take")

> ; note: deleting unreachable code
> ; note: deleting unreachable code
> ; compilation unit finished
> ;  printed 2 notes
>  ✓ take 

fixes #101 - take with a too big end limit raises a bounding indices error