### PR TITLE
Added support for clasp Common Lisp to cl21

### DIFF
--- a/src/cl21.lisp
+++ b/src/cl21.lisp
@@ -17,11 +17,12 @@
   (:use :cl21))
 (cl21::in-package :cl21-user)
 
-#+(or sbcl ccl clisp allegro ecl)
+#+(or sbcl ccl clisp allegro ecl clasp)
 (cl:do-external-symbols (#1=#:symb
                          #+sbcl    :sb-ext
                          #+ccl     :ccl
                          #+clisp   :ext
                          #+allegro :excl
-                         #+ecl     :quit)
+                         #+ecl     :quit
+                         #+clasp   :ext)
   (cl:shadowing-import (cl:list #1#)))

--- a/src/core/environment.lisp
+++ b/src/core/environment.lisp
@@ -6,8 +6,9 @@
         #+cmu :ext
         #+allegro :sys
         #+ecl :si
+        #+clasp :clasp-cltl2
         #+abcl :lisp)
-  #+(or sbcl openmcl cmu allegro ecl abcl)
+  #+(or sbcl openmcl cmu allegro ecl clasp abcl)
   (:export :compiler-let
            :variable-information
            :function-information

--- a/src/internal/util.lisp
+++ b/src/internal/util.lisp
@@ -6,6 +6,7 @@
                 #+cmu :ext
                 #+allegro :sys
                 #+ecl :si
+                #+clasp :clasp-cltl2
                 #+abcl :lisp
                 :variable-information)
   (:import-from :alexandria


### PR DESCRIPTION
Clasp Common Lisp is the newest implementation of Common Lisp.
It's at http://github.com/clasp-developers/clasp.git.
We would like to take advantage of cl21 developments and so
we have added #+clasp feature tests to cl21.